### PR TITLE
Fix missing rule for 24 month term

### DIFF
--- a/CotizacionLeasing.Application/Validators/QuoteRequestValidator.cs
+++ b/CotizacionLeasing.Application/Validators/QuoteRequestValidator.cs
@@ -33,17 +33,17 @@ namespace CotizacionLeasing.Application.Validators
                 .When(x => x.TermMonths == 12)
                 .WithMessage("Para 12 meses, enganche mínimo de 10%.");
 
-            // 4b. Enganche mínimo 7.5% para 13–23 meses
+            // 4b. Enganche mínimo 7.5% para 13–24 meses
             RuleFor(x => x.DownPayment)
                 .GreaterThanOrEqualTo(x => x.Price * 0.075m)
-                .When(x => x.TermMonths >= 13 && x.TermMonths <= 23)
-                .WithMessage("Para 13–23 meses, enganche mínimo de 7.5%.");
+                .When(x => x.TermMonths >= 13 && x.TermMonths <= 24)
+                .WithMessage("Para 13–24 meses, enganche mínimo de 7.5%.");
 
-            // 4c. Enganche mínimo 5% para más de 24 meses
+            // 4c. Enganche mínimo 5% para 25 meses o más
             RuleFor(x => x.DownPayment)
                 .GreaterThanOrEqualTo(x => x.Price * 0.05m)
-                .When(x => x.TermMonths > 24)
-                .WithMessage("Para más de 24 meses, enganche mínimo de 5%.");
+                .When(x => x.TermMonths >= 25)
+                .WithMessage("Para 25 meses o más, enganche mínimo de 5%.");
 
             // 5. Plazo en meses > 0
             RuleFor(x => x.TermMonths)

--- a/CotizacionLeasing.Domain/Entities/Quote.cs
+++ b/CotizacionLeasing.Domain/Entities/Quote.cs
@@ -71,8 +71,8 @@ namespace CotizacionLeasing.Domain.Entities
         /// - Residual > 30% del precio.
         /// - Enganche mínimo no alcanzado según el plazo:
         ///   * 12 meses → ≥ 10%
-        ///   * 13–23 meses → ≥ 7.5%
-        ///   * > 24 meses → ≥ 5%
+        ///   * 13–24 meses → ≥ 7.5%
+        ///   * ≥ 25 meses  → ≥ 5%
         /// </exception>
         public Quote(
             Client client,
@@ -89,10 +89,10 @@ namespace CotizacionLeasing.Domain.Entities
             // 2. Validar enganche mínimo según plazo
             if (termMonths == 12 && downPayment < price * 0.10m)
                 throw new BusinessRuleException("Para 12 meses, enganche mínimo de 10%.");
-            if (termMonths is >= 13 and <= 23 && downPayment < price * 0.075m)
-                throw new BusinessRuleException("Para 13–23 meses, enganche mínimo de 7.5%.");
-            if (termMonths > 24 && downPayment < price * 0.05m)
-                throw new BusinessRuleException("Para más de 24 meses, enganche mínimo de 5%.");
+            if (termMonths is >= 13 and <= 24 && downPayment < price * 0.075m)
+                throw new BusinessRuleException("Para 13–24 meses, enganche mínimo de 7.5%.");
+            if (termMonths >= 25 && downPayment < price * 0.05m)
+                throw new BusinessRuleException("Para 25 meses o más, enganche mínimo de 5%.");
 
             // Asignación de propiedades
             Id             = Guid.NewGuid();

--- a/CotizacionLeasing.Tests/QuoteTests.cs
+++ b/CotizacionLeasing.Tests/QuoteTests.cs
@@ -56,8 +56,8 @@ namespace CotizacionLeasing.Tests
 
         [Theory]
         [InlineData(12, 9000.0, "Para 12 meses")]
-        [InlineData(18, 7000.0, "Para 13–23 meses")]
-        [InlineData(36, 4000.0, "Para más de 24 meses")]
+        [InlineData(18, 7000.0, "Para 13–24 meses")]
+        [InlineData(36, 4000.0, "Para 25 meses o más")]
         public void DownPaymentTooLow_ShouldHaveValidationError(int term, double dpDouble, string containsMsg)
         {
             // Convertimos el double a decimal para construir el DTO
@@ -102,12 +102,12 @@ namespace CotizacionLeasing.Tests
                 new Quote(new Client("X"), 100_000m, 5_000m, 12, 10_000m, 0.1));
 
         [Fact]
-        public void DownPaymentRule13To23MonthsViolation_ShouldThrowBusinessRuleException() =>
+        public void DownPaymentRule13To24MonthsViolation_ShouldThrowBusinessRuleException() =>
             Assert.Throws<BusinessRuleException>(() =>
                 new Quote(new Client("X"), 100_000m, 6_000m, 18, 10_000m, 0.1));
 
         [Fact]
-        public void DownPaymentRuleGreater24MonthsViolation_ShouldThrowBusinessRuleException() =>
+        public void DownPaymentRuleGreaterOrEqual25MonthsViolation_ShouldThrowBusinessRuleException() =>
             Assert.Throws<BusinessRuleException>(() =>
                 new Quote(new Client("X"), 100_000m, 4_000m, 36, 10_000m, 0.1));
 


### PR DESCRIPTION
## Summary
- adjust down payment rules to cover 24 month terms
- update validator logic
- update affected tests

## Testing
- `dotnet test --no-build --nologo` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430ace4f688322bacd5799f306c16f